### PR TITLE
Encode string to UTF-8 to prevent issues where ASCII fails to decode characters

### DIFF
--- a/nucos/unit_conversion.py
+++ b/nucos/unit_conversion.py
@@ -168,8 +168,10 @@ def FindUnitTypes():
                 if (unit_type, n) in [("volume", "oz"),
                                       ("density", "s")]:
                     continue
-
-                print(f"Adding: {unit_type}: {n}".encode("utf-8"))
+                try:
+                    print(f"Adding: {unit_type}: {n}")
+                except UnicodeEncodeError:
+                    print(f"Adding: {unit_type}: {n}".encode("utf-8"))
                 if n in unit_types:
                     raise ValueError("Duplicate name in units table: %s" % n)
 

--- a/nucos/unit_conversion.py
+++ b/nucos/unit_conversion.py
@@ -169,7 +169,7 @@ def FindUnitTypes():
                                       ("density", "s")]:
                     continue
 
-                print(f"Adding: {unit_type}: {n}")
+                print(f"Adding: {unit_type}: {n}".encode("utf-8"))
                 if n in unit_types:
                     raise ValueError("Duplicate name in units table: %s" % n)
 


### PR DESCRIPTION
Some Python environments are not able to decode special characters used in this print statement. Workarounds includes adding or changing some python variables or modifying an environment to default to UTF-8. After adding .encode("utf-8"), these workarounds are not needed anymore, as it seems only this line was causing UnicodeEncodeError.